### PR TITLE
Rendering optimizations.

### DIFF
--- a/js/nl/kingsquare/as3/flash/display/BitmapData.js
+++ b/js/nl/kingsquare/as3/flash/display/BitmapData.js
@@ -39,15 +39,15 @@
 			}
 			this.pixelData = pixelData;
 		},
-
-		fillRect: function (rect/*:Rectangle*/, color/*:uint*/) {
+		
+/*
+		fillRect: function (rect, color) {//Rectangle:rect,uint:color
 			this.context.clearRect(rect.x, rect.y, rect.width, rect.height);
 			this.context.fillStyle = 'rgba(' + ((color >> 16) & 0xFF) +
 					',' + ((color >> 8) & 0xFF) + ',' + ((color >> 0) & 0xFF) +
 					', ' + ((color >> 24) & 0xFF) / 255 + ')';
 			this.context.fillRect(rect.x, rect.y, rect.width, rect.height);
 		},
-
 		setPixel32: function (x, y, color) {
 			var data = this.pixelData.data;
 
@@ -62,6 +62,37 @@
 
 			// Draw the ImageData object.
 			this.context.putImageData(this.pixelData, x, y);
+		},
+*/
+
+		colorMap:{},
+		translateColor:function(color){
+			var col = 'rgba(' + ((color >> 16) & 0xFF) +',' + ((color >> 8) & 0xFF) + ',' + ((color >> 0) & 0xFF) + ',1)';
+			this.colorMap[color]=col;
+			return col;
+		},
+		fillRect: function (rect, color) {//:Rectangle,:uint
+			if(color==0){
+				this.context.clearRect(rect.x, rect.y, rect.width, rect.height);
+				return;
+			}
+			if(this.lastFillColor!=color){
+				this.lastFillColor=color;
+				var col = this.colorMap[color];
+				if(col==undefined)col = this.translateColor(color);
+				this.context.fillStyle = col;
+			}
+			this.context.fillRect(rect.x, rect.y, rect.width, rect.height);
+		},
+		setPixel32: function (x, y, color) {
+			if(this.lastFillColor!=color){
+				this.lastFillColor=color;
+				var col = this.colorMap[color];
+				if(col==undefined)col = this.translateColor(color);
+				this.context.fillStyle = col;
+			}
+			this.context.fillRect(x|0,y|0,1,1);
 		}
 	});
 }());
+

--- a/js/nl/kingsquare/c64/screen/Renderer.js
+++ b/js/nl/kingsquare/c64/screen/Renderer.js
@@ -69,7 +69,7 @@
 				self['display' + canvasId + 'OffScreen'].width = self.canvasWidth;
 				self['display' + canvasId + 'OffScreen'].height = self.canvasHeight;
 				self['display' + canvasId]  = new nl.kingsquare.as3.flash.display.BitmapData(self['display' + canvasId
-						+ 'OffScreen'].getContext('2d'));
+						+ 'OffScreen'].getContext('2d',{alpha:true}));
 				self['display' + canvasId + 'OnScreen'] = $('<canvas class="display' + canvasId
 						+ '" style="position: absolute; top: 0px; left: 0px;" width="' + self.canvasWidth
 						+ '" height="' + self.canvasHeight + '" />').appendTo(container)[0];


### PR DESCRIPTION
Some simple optimizations to the rendering routines.

I changed setPixel32 to use a fillrect of size 1 instead of the putImageData trick.
I only recompute the fillStyle if the color has changed...
Additionally, I cache the computed fillStyle string for each color encountered in a map, since the c64 palette is so small, in practice this map shouldn't get very large.
